### PR TITLE
Switch from windows-2019 runners to windows-latest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
           #   build-command: npm run create-mac-x64-dist
           #   os: macos
           #   arch: x64
-          - runs-on: windows-2019
+          - runs-on: windows-latest
             artifact-name: core-registry-api-windows-x64
             build-command: npm run create-win-x64-dist
             os: windows
@@ -61,7 +61,7 @@ jobs:
 
       # Install wget on Windows
       - name: Install wget on Windows
-        if: matrix.runs-on == 'windows-2019'
+        if: matrix.runs-on == 'windows-latest'
         run: choco install wget -y --no-progress
 
       # Install jq on Linux if not already installed
@@ -176,7 +176,7 @@ jobs:
 
       # Windows Code Signing
       - name: Sign windows artifacts
-        if: matrix.runs-on == 'windows-2019' && steps.check_secrets.outputs.HAS_SIGNING_SECRET
+        if: matrix.runs-on == 'windows-latest' && steps.check_secrets.outputs.HAS_SIGNING_SECRET
         uses: chia-network/actions/digicert/windows-sign@main
         with:
           sm_certkey_alias: ${{ secrets.SM_CERTKEY_ALIAS }}


### PR DESCRIPTION
This PR replaces 'windows-2019' with 'windows-latest' in GitHub Actions workflows to ensure compatibility and leverage the latest features and security updates.